### PR TITLE
Reword error msg to distinguish between service and server

### DIFF
--- a/src/usocket.c
+++ b/src/usocket.c
@@ -439,12 +439,12 @@ const char *socket_gaistrerror(int err) {
         case EAI_FAMILY: return "ai_family not supported";
         case EAI_MEMORY: return "memory allocation failure";
         case EAI_NONAME: 
-            return "hostname or servname not provided, or not known";
+            return "host or service not provided, or not known";
         case EAI_OVERFLOW: return "argument buffer overflow";
 #ifdef EAI_PROTOCOL
         case EAI_PROTOCOL: return "resolved protocol is unknown";
 #endif
-        case EAI_SERVICE: return "servname not supported for socktype";
+        case EAI_SERVICE: return "service not supported for socket type";
         case EAI_SOCKTYPE: return "ai_socktype not supported";
         case EAI_SYSTEM: return strerror(errno); 
         default: return "unknown error";


### PR DESCRIPTION
servname is easily confused with "server name", making it seem
as if the server name couldn't be resolved.

I just spent a few minutes, confusingly trying to figure out why DNS resolution for my server's name wasn't working, only to realize servname meant "service name" not "server name"...
