### PR TITLE
socket.connect now implemented in the C core

### DIFF
--- a/doc/reference.html
+++ b/doc/reference.html
@@ -145,6 +145,8 @@ Support, Manual">
 <blockquote>
 <a href="socket.html#bind">bind</a>,
 <a href="socket.html#connect">connect</a>,
+<a href="socket.html#connect">connect4</a>,
+<a href="socket.html#connect">connect6</a>,
 <a href="socket.html#debug">_DEBUG</a>,
 <a href="dns.html#dns">dns</a>,
 <a href="socket.html#gettime">gettime</a>,

--- a/doc/socket.html
+++ b/doc/socket.html
@@ -73,14 +73,19 @@ set to <tt><b>true</b></tt>.
 <!-- connect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
 <p class=name id=connect> 
-socket.<b>connect(</b>address, port [, locaddr, locport]<b>)</b>
+socket.<b>connect[46](</b>address, port [, locaddr] [, locport] [, family]<b>)</b>
 </p>
 
 <p class=description>
 This function is a shortcut that creates and returns a TCP client object
-connected to a remote <tt>host</tt> at a given <tt>port</tt>. Optionally,
+connected to a remote <tt>address</tt> at a given <tt>port</tt>. Optionally,
 the user can also specify the local address and port to bind
-(<tt>locaddr</tt> and <tt>locport</tt>).
+(<tt>locaddr</tt> and <tt>locport</tt>), or restrict the socket family
+to "<tt>inet</tt>" or "<tt>inet6</tt>".
+Without specifying <tt>family</tt> to <tt>connect</tt>, whether a tcp or tcp6
+connection is created depends on your system configuration. Two variations
+of connect are defined as simple helper functions that restrict the
+<tt>family</tt>, <tt>socket.connect4</tt> and <tt>socket.connect6</tt>.
 </p>
 
 <!-- debug ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->

--- a/src/inet.h
+++ b/src/inet.h
@@ -33,6 +33,9 @@ const char *inet_trybind(p_socket ps, const char *address, const char *serv,
 int inet_meth_getpeername(lua_State *L, p_socket ps, int family);
 int inet_meth_getsockname(lua_State *L, p_socket ps, int family);
 
+int inet_optfamily(lua_State* L, int narg, const char* def);
+int inet_optsocktype(lua_State* L, int narg, const char* def);
+
 #ifdef INET_ATON
 int inet_aton(const char *cp, struct in_addr *inp);
 #endif

--- a/src/socket.lua
+++ b/src/socket.lua
@@ -15,34 +15,12 @@ module("socket")
 -----------------------------------------------------------------------------
 -- Exported auxiliar functions
 -----------------------------------------------------------------------------
-function connect(address, port, laddress, lport)
-    if address == "*" then address = "0.0.0.0" end
-    local addrinfo, err = socket.dns.getaddrinfo(address);
-    if not addrinfo then return nil, err end
-    local sock, res
-    err = "no info on address"
-    for i, alt in base.ipairs(addrinfo) do 
-        if alt.family == "inet" then
-            sock, err = socket.tcp()
-        else
-            sock, err = socket.tcp6()
-        end
-        if not sock then return nil, err end
-        if laddress then
-            res, err = sock:bind(laddress, lport)
-            if not res then 
-                sock:close()
-                return nil, err 
-            end
-        end
-        res, err = sock:connect(alt.addr, port)
-        if not res then 
-            sock:close()
-        else
-            return sock 
-        end
-    end
-    return nil, err
+function connect4(address, port, laddress, lport)
+    return socket.connect(address, port, laddress, lport, "inet")
+end
+
+function connect6(address, port, laddress, lport)
+    return socket.connect(address, port, laddress, lport, "inet6")
 end
 
 function bind(host, port, backlog)

--- a/src/usocket.c
+++ b/src/usocket.c
@@ -447,7 +447,7 @@ const char *socket_gaistrerror(int err) {
         case EAI_SERVICE: return "service not supported for socket type";
         case EAI_SOCKTYPE: return "ai_socktype not supported";
         case EAI_SYSTEM: return strerror(errno); 
-        default: return "unknown error";
+        default: return gai_strerror(err);
     }
 }
 


### PR DESCRIPTION
This avoid socket.lua duplicating the iteration over the results
of getaddrinfo(). Some problems with the C implementation not
initializing sockets or the luasocket family have also been fixed,
and error reporting made more robust.
