### PR TITLE
src/makefile: Add lua to the lua include path

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -39,7 +39,7 @@ LUAPREFIX_macosx?=/opt/local/
 # /usr/local/include 
 # /usr/local/include/lua$(LUAV)
 # where lua headers are found for linux builds
-LUAINC_linux_base?=/usr/include
+LUAINC_linux_base?=/usr/include/lua
 LUAINC_linux?=$(LUAINC_linux_base)$(LUAV)
 LUAPREFIX_linux?=/usr/local
 


### PR DESCRIPTION
Commit 05535a19f81d181b7e15d241892e794a00905bb9 broke building on linux. This fixes it by correcting the Lua include path.
