### PR TITLE
fix use of arg in ltn12

### DIFF
--- a/src/ltn12.lua
+++ b/src/ltn12.lua
@@ -37,7 +37,8 @@ end
 -- chains a bunch of filters together
 -- (thanks to Wim Couwenberg)
 function filter.chain(...)
-    local n = table.getn(arg)
+    local arg = {...}
+    local n = #arg
     local top, index = 1, 1
     local retry = ""
     return function(chunk)
@@ -185,6 +186,7 @@ end
 -- other, as if they were concatenated
 -- (thanks to Wim Couwenberg)
 function source.cat(...)
+    local arg = {...}
     local src = table.remove(arg, 1)
     return function()
         while src do


### PR DESCRIPTION
`arg` is not part of Lua 5.1 and hence no longer works in Lua 5.2 or LuaJIT with its default compilation options.

Note that `arg` is apparently used in other parts of the codebase, but I have only hit this issue in ltn12 so far. If you think this fix is correct I can git a try at hunting use of `arg` in other places.
