### PR TITLE
Copied socket_gaistrerror implementation from usocket to wsocket to allo...

### DIFF
--- a/src/wsocket.c
+++ b/src/wsocket.c
@@ -397,3 +397,28 @@ static const char *wstrerror(int err) {
         default: return "Unknown error";
     }
 }
+
+const char *socket_gaistrerror(int err) {
+    if (err == 0) return NULL; 
+    switch (err) {
+        case EAI_AGAIN: return "temporary failure in name resolution";
+        case EAI_BADFLAGS: return "invalid value for ai_flags";
+#ifdef EAI_BADHINTS
+        case EAI_BADHINTS: return "invalid value for hints";
+#endif
+        case EAI_FAIL: return "non-recoverable failure in name resolution";
+        case EAI_FAMILY: return "ai_family not supported";
+        case EAI_MEMORY: return "memory allocation failure";
+        case EAI_NONAME: 
+            return "host or service not provided, or not known";
+//        case EAI_OVERFLOW: return "argument buffer overflow";
+#ifdef EAI_PROTOCOL
+        case EAI_PROTOCOL: return "resolved protocol is unknown";
+#endif
+        case EAI_SERVICE: return "service not supported for socket type";
+        case EAI_SOCKTYPE: return "ai_socktype not supported";
+//        case EAI_SYSTEM: return strerror(errno); 
+        default: return gai_strerror(err);
+    }
+}
+


### PR DESCRIPTION
...w Windows version to compile because it is missing the function. EAI_OVERFLOW and EAI_SYSTEM are commented out because they don't exist on Windows.
