### PR TITLE
Use the length operator (#) instead of table.getn.

### DIFF
--- a/etc/check-links.lua
+++ b/etc/check-links.lua
@@ -11,7 +11,7 @@ dispatch.TIMEOUT = 10
 
 -- make sure the user knows how to invoke us
 arg = arg or {}
-if table.getn(arg) < 1 then
+if #arg < 1 then
     print("Usage:\n  luasocket check-links.lua [-n] {<url>}")
     exit()
 end

--- a/etc/dispatch.lua
+++ b/etc/dispatch.lua
@@ -76,7 +76,7 @@ local function newset()
         insert = function(set, value)
             if not reverse[value] then
                 table.insert(set, value)
-                reverse[value] = table.getn(set)
+                reverse[value] = #set
             end
         end,
         remove = function(set, value)

--- a/etc/forward.lua
+++ b/etc/forward.lua
@@ -3,7 +3,7 @@ local dispatch = require("dispatch")
 local handler = dispatch.newhandler()
 
 -- make sure the user knows how to invoke us
-if table.getn(arg) < 1 then
+if #arg < 1 then
     print("Usage")
     print("    lua forward.lua <iport:ohost:oport> ...")
     os.exit(1)

--- a/etc/get.lua
+++ b/etc/get.lua
@@ -135,7 +135,7 @@ end
 
 -- main program
 arg = arg or {}
-if table.getn(arg) < 1 then
+if #arg < 1 then
     io.write("Usage:\n  lua get.lua <remote-url> [<local-file>]\n")
     os.exit(1)
 else get(arg[1], arg[2]) end

--- a/samples/lpr.lua
+++ b/samples/lpr.lua
@@ -29,7 +29,7 @@ end
 do
     local opt = {}
     local pat = "[%s%c%p]*([%w]*)=([\"]?[%w%s_!@#$%%^&*()<>:;]+[\"]\?\.?)"
-    for i = 2, table.getn(arg), 1 do
+    for i = 2, #arg, 1 do
       string.gsub(arg[i], pat, function(name, value) opt[name] = value end)
     end
     if not arg[2] then

--- a/samples/tinyirc.lua
+++ b/samples/tinyirc.lua
@@ -31,7 +31,7 @@ function newset()
         insert = function(set, value)
             if not reverse[value] then
                 table.insert(set, value)
-                reverse[value] = table.getn(set)
+                reverse[value] = #set
             end
         end,
         remove = function(set, value)

--- a/src/mbox.lua
+++ b/src/mbox.lua
@@ -34,7 +34,7 @@ end
 function Public.parse_headers(headers_s)
     local headers_t = Public.split_headers(headers_s)
     local headers = {}
-    for i = 1, table.getn(headers_t) do
+    for i = 1, #headers_t do
         local name, value = Public.parse_header(headers_t[i])
         if name then
             name = string.lower(name)
@@ -74,7 +74,7 @@ end
 
 function Public.parse(mbox_s)
     local mbox = Public.split_mbox(mbox_s)
-    for i = 1, table.getn(mbox) do
+    for i = 1, #mbox do
         mbox[i] = Public.parse_message(mbox[i])
     end
     return mbox

--- a/src/url.lua
+++ b/src/url.lua
@@ -259,7 +259,7 @@ function parse_path(path)
     path = path or ""
     --path = string.gsub(path, "%s", "")
     string.gsub(path, "([^/]+)", function (s) table.insert(parsed, s) end)
-    for i = 1, table.getn(parsed) do
+    for i = 1, #parsed do
         parsed[i] = unescape(parsed[i])
     end
     if string.sub(path, 1, 1) == "/" then parsed.is_absolute = 1 end
@@ -277,7 +277,7 @@ end
 -----------------------------------------------------------------------------
 function build_path(parsed, unsafe)
     local path = ""
-    local n = table.getn(parsed)
+    local n = #parsed
     if unsafe then
         for i = 1, n-1 do
             path = path .. parsed[i]

--- a/test/httptest.lua
+++ b/test/httptest.lua
@@ -66,7 +66,7 @@ local check_request = function(request, expect, ignore)
     local response = {}
     response.code, response.headers, response.status = 
         socket.skip(1, http.request(request))
-    if t and table.getn(t) > 0 then response.body = table.concat(t) end
+    if t and #t > 0 then response.body = table.concat(t) end
     check_result(response, expect, ignore)
 end
 

--- a/test/smtptest.lua
+++ b/test/smtptest.lua
@@ -20,7 +20,7 @@ dofile("testsupport.lua")
 
 local total = function()
     local t = 0
-    for i = 1, table.getn(sent) do
+    for i = 1, #sent do
         t = t + sent[i].count
     end
     return t
@@ -83,7 +83,7 @@ end
 
 local check = function(sent, m)
     io.write("checking ", m.headers.title, ": ")
-    for i = 1, table.getn(sent) do
+    for i = 1, #sent do
         local s = sent[i]
         if s.title == m.headers.title and s.count > 0 then
             check_headers(s.headers, m.headers)
@@ -98,7 +98,7 @@ end
 
 local insert = function(sent, message)
     if type(message.rcpt) == "table" then
-        message.count = table.getn(message.rcpt)
+        message.count = #message.rcpt
     else message.count = 1 end
     message.headers = message.headers or {}
     message.headers.title = message.title
@@ -115,7 +115,7 @@ local wait = function(sentinel, n)
     io.write("waiting for ", n, " messages: ")
     while 1 do
         local mbox = parse(get())
-        if n == table.getn(mbox) then break end
+        if n == #mbox then break end
         if socket.time() - sentinel.time > 50 then 
             to = 1 
             break
@@ -237,7 +237,7 @@ empty()
 print("ok")
 
 io.write("sending messages: ")
-for i = 1, table.getn(sent) do
+for i = 1, #sent do
     ret, err = socket.smtp.mail(sent[i])
     if not ret then fail(err) end
     io.write("+")
@@ -249,9 +249,9 @@ wait(mark(), total())
 
 io.write("parsing mailbox: ")
 local mbox = parse(get())
-print(table.getn(mbox) .. " messages found!")
+print(#mbox .. " messages found!")
 
-for i = 1, table.getn(mbox) do
+for i = 1, #mbox do
     check(sent, mbox[i])
 end
 

--- a/test/urltest.lua
+++ b/test/urltest.lua
@@ -34,7 +34,7 @@ end
 
 local check_parse_path = function(path, expect)
     local parsed = socket.url.parse_path(path)
-    for i = 1, math.max(table.getn(parsed), table.getn(expect)) do
+    for i = 1, math.max(#parsed, #expect) do
         if parsed[i] ~= expect[i] then
             print(path)
             os.exit()


### PR DESCRIPTION
table.getn was deprecated in Lua 5.1 in favor of #, the length operator.
See: http://www.lua.org/manual/5.1/manual.html#7.2
