### PR TITLE
Add. acceptfd method.

### DIFF
--- a/test/test_acceptfd.lua
+++ b/test/test_acceptfd.lua
@@ -1,0 +1,22 @@
+local socket = require "socket"
+
+local host, port = "127.0.0.1", "5462"
+
+local srv = assert(socket.bind(host, port))
+
+local sock = socket.tcp()
+assert(sock:connect(host, port))
+
+local fd = assert(srv:acceptfd())
+assert(type(fd) == "number")
+
+local cli = assert(socket.tcp(fd, "client"))
+
+assert(5 == assert(cli:send("hello")))
+assert("hello" == assert(sock:receive(5)))
+
+cli:close()
+sock:close()
+srv:close()
+
+print("done!")


### PR DESCRIPTION
On windows we can pass this `fd` only between threads.

`socket.tcp` can accept fd and socket type ('master'(default), 'client') and create new `socket` object.

acceptfd method can be used to write multi-threaded server.

``` lua
-- main thread
local fd = srv_sock:acceptfd()
Threads.runfile('echo.lua', fd)

-- echo.lua
local fd = ...
local sock = socket.tcp(fd,'client')
```

or to interact with library such as [ESL](http://wiki.freeswitch.org/wiki/Event_Socket_Library)

``` lua
local fd = srv_sock:acceptfd()
Threads.runfile('worker.lua', fd)

-- worker.lua
local sock = ESLconnection((...))
```

If we need just close fd (for example we can not run worker thread) we should call `socket.tcp(fd,'client'):close()`
