### PR TITLE
Fix. recive 2xx while ftp.get cause timeout error

### DIFF
--- a/src/ftp.lua
+++ b/src/ftp.lua
@@ -142,7 +142,11 @@ function metat.__index:receive(recvt)
     if argument == "" then argument = nil end
     local command = recvt.command or "retr"
     self.try(self.tp:command(command, argument))
-    local code = self.try(self.tp:check{"1..", "2.."})
+    local code,reply = self.try(self.tp:check{"1..", "2.."})
+    if (code >= 200) and (code <= 299) then
+        recvt.sink(reply)
+        return 1
+    end
     if not self.pasvt then self:portconnect() end
     local source = socket.source("until-closed", self.data)
     local step = recvt.step or ltn12.pump.step


### PR DESCRIPTION
In this example:

> Client send: MDTM test.txt
> Server response: 213 20120824120909
> Because FTP server do not open new channel (2XX response)
> and LuaSocket try open new channel we get timeout.

``` lua
local ftp   = require "socket.ftp"
local ltn12 = require "ltn12"
local url   = require("socket.url")

local URL = "ftp://USER:TEST@127.0.0.1";
local CMD = 'MDTM test.txt';

-- get timeout
ftp.get{
  url = URL;
  command = CMD;
  sink = ltn12.sink.table{};
}

-- or we can use ftp.command
ftp.command{
  url = URL;
  command = URL,
  check = function(...)
    local status, data = ...
    return true
  end;
}
```
