### PR TITLE
fixes related to constants in the HTTP module

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -186,7 +186,7 @@ end
 local function adjusturi(reqt)
     local u = reqt
     -- if there is a proxy, we need the full url. otherwise, just a part.
-    if not reqt.proxy and not PROXY then
+    if not reqt.proxy and not _M.PROXY then
         u = {
            path = socket.try(reqt.path, "invalid path 'nil'"),
            params = reqt.params,
@@ -198,7 +198,7 @@ local function adjusturi(reqt)
 end
 
 local function adjustproxy(reqt)
-    local proxy = reqt.proxy or PROXY
+    local proxy = reqt.proxy or _M.PROXY
     if proxy then
         proxy = url.parse(proxy)
         return proxy.host, proxy.port or 3128


### PR DESCRIPTION
These two commits fix small issues with constants in the HTTP module.

The first one is that the default value of TIMEOUT is [declared as a global](https://github.com/diegonehab/luasocket/blob/22cd5833fcc0e272f26004a79c8545e959ba406b/src/http.lua#L25) but then the code is [looking for it in _M](https://github.com/diegonehab/luasocket/blob/22cd5833fcc0e272f26004a79c8545e959ba406b/src/http.lua#L116). The fix puts the default value in _M too.

The second one is that the module reads the PROXY global without declaring it first. This causes errors when making HTTP requests with a script like _pl.strict_ from Penlight loaded:

```
socket/http.lua:189: variable 'PROXY' is not declared
```

The fix here is, again, to look in _M instead of the global namespace (like for the other "constants").
