### PR TITLE
Include port in default Host header

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -209,9 +209,11 @@ end
 
 local function adjustheaders(reqt)
     -- default headers
+    local host = reqt.host
+    if reqt.port then host = host .. ":" .. reqt.port end
     local lower = {
         ["user-agent"] = _M.USERAGENT,
-        ["host"] = reqt.host,
+        ["host"] = host,
         ["connection"] = "close, TE",
         ["te"] = "trailers"
     }


### PR DESCRIPTION
See [RFC 2616 section 14.23](http://tools.ietf.org/html/rfc2616#section-14.23): if the port is not the default it should be included in the Host header.

Currently it is not and it actually results in `404` errors with strict HTTP servers like [the Flask stack with SERVER_NAME set](http://flask.pocoo.org/docs/config/).

This pull request fixes this by appending the port if needed.
