### PR TITLE
Added ability to set the option `reuseport` of a tcp socket.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -44,7 +44,7 @@ int opt_get_reuseaddr(lua_State *L, p_socket ps);
 int opt_get_tcp_nodelay(lua_State *L, p_socket ps);
 int opt_get_keepalive(lua_State *L, p_socket ps);
 int opt_get_linger(lua_State *L, p_socket ps);
-int opt_get_reuseaddr(lua_State *L, p_socket ps);
+int opt_get_reuseport(lua_State *L, p_socket ps);
 int opt_get_ip_multicast_loop(lua_State *L, p_socket ps);
 int opt_get_ip_multicast_if(lua_State *L, p_socket ps);
 int opt_get_error(lua_State *L, p_socket ps);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -71,6 +71,7 @@ static luaL_Reg tcp_methods[] = {
 static t_opt optget[] = {
     {"keepalive",   opt_get_keepalive},
     {"reuseaddr",   opt_get_reuseaddr},
+    {"reuseport",   opt_get_reuseport},
     {"tcp-nodelay", opt_get_tcp_nodelay},
     {"linger",      opt_get_linger},
     {"error",       opt_get_error},
@@ -80,6 +81,7 @@ static t_opt optget[] = {
 static t_opt optset[] = {
     {"keepalive",   opt_set_keepalive},
     {"reuseaddr",   opt_set_reuseaddr},
+    {"reuseport",   opt_set_reuseport},
     {"tcp-nodelay", opt_set_tcp_nodelay},
     {"ipv6-v6only", opt_set_ip6_v6only},
     {"linger",      opt_set_linger},


### PR DESCRIPTION
Enables the option `reuseport` to be set on TCP servers so many of them can bind to the same address.