### PR TITLE
fix build with uClibc without IPv6

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -110,6 +110,7 @@ int opt_set_broadcast(lua_State *L, p_socket ps)
     return opt_setboolean(L, ps, SOL_SOCKET, SO_BROADCAST);
 }
 
+#ifdef IPV6_UNICAST_HOPS
 int opt_set_ip6_unicast_hops(lua_State *L, p_socket ps)
 {
   return opt_setint(L, ps, IPPROTO_IPV6, IPV6_UNICAST_HOPS);
@@ -119,7 +120,9 @@ int opt_get_ip6_unicast_hops(lua_State *L, p_socket ps)
 {
   return opt_getint(L, ps, IPPROTO_IPV6, IPV6_UNICAST_HOPS);
 }
+#endif
 
+#ifdef IPV6_MULTICAST_HOPS
 int opt_set_ip6_multicast_hops(lua_State *L, p_socket ps)
 {
   return opt_setint(L, ps, IPPROTO_IPV6, IPV6_MULTICAST_HOPS);
@@ -129,6 +132,7 @@ int opt_get_ip6_multicast_hops(lua_State *L, p_socket ps)
 {
   return opt_getint(L, ps, IPPROTO_IPV6, IPV6_MULTICAST_HOPS);
 }
+#endif
 
 int opt_set_ip_multicast_loop(lua_State *L, p_socket ps)
 {
@@ -140,6 +144,7 @@ int opt_get_ip_multicast_loop(lua_State *L, p_socket ps)
     return opt_getboolean(L, ps, IPPROTO_IP, IP_MULTICAST_LOOP);
 }
 
+#ifdef IPV6_MULTICAST_LOOP
 int opt_set_ip6_multicast_loop(lua_State *L, p_socket ps)
 {
     return opt_setboolean(L, ps, IPPROTO_IPV6, IPV6_MULTICAST_LOOP);
@@ -149,6 +154,7 @@ int opt_get_ip6_multicast_loop(lua_State *L, p_socket ps)
 {
     return opt_getboolean(L, ps, IPPROTO_IPV6, IPV6_MULTICAST_LOOP);
 }
+#endif
 
 int opt_set_linger(lua_State *L, p_socket ps)
 {
@@ -221,16 +227,21 @@ int opt_set_ip_drop_membersip(lua_State *L, p_socket ps)
     return opt_setmembership(L, ps, IPPROTO_IP, IP_DROP_MEMBERSHIP);
 }
 
+#ifdef IPV6_ADD_MEMBERSHIP
 int opt_set_ip6_add_membership(lua_State *L, p_socket ps)
 {
     return opt_ip6_setmembership(L, ps, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP);
 }
+#endif
 
+#ifdef IPV6_DROP_MEMBERSHIP
 int opt_set_ip6_drop_membersip(lua_State *L, p_socket ps)
 {
     return opt_ip6_setmembership(L, ps, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP);
 }
+#endif
 
+#ifdef IPV6_V6ONLY
 int opt_get_ip6_v6only(lua_State *L, p_socket ps)
 {
     return opt_getboolean(L, ps, IPPROTO_IPV6, IPV6_V6ONLY);
@@ -240,6 +251,7 @@ int opt_set_ip6_v6only(lua_State *L, p_socket ps)
 {
     return opt_setboolean(L, ps, IPPROTO_IPV6, IPV6_V6ONLY);
 }
+#endif
 
 /*=========================================================================*\
 * Auxiliar functions

--- a/src/options.h
+++ b/src/options.h
@@ -32,12 +32,24 @@ int opt_set_ip_multicast_ttl(lua_State *L, p_socket ps);
 int opt_set_ip_multicast_loop(lua_State *L, p_socket ps);
 int opt_set_ip_add_membership(lua_State *L, p_socket ps);
 int opt_set_ip_drop_membersip(lua_State *L, p_socket ps);
+#ifdef IPV6_UNICAST_HOPS
 int opt_set_ip6_unicast_hops(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_MULTICAST_HOPS
 int opt_set_ip6_multicast_hops(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_MULTICAST_LOOP
 int opt_set_ip6_multicast_loop(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_ADD_MEMBERSHIP
 int opt_set_ip6_add_membership(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_DROP_MEMBERSHIP
 int opt_set_ip6_drop_membersip(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_V6ONLY
 int opt_set_ip6_v6only(lua_State *L, p_socket ps);
+#endif
 
 /* supported options for getoption */
 int opt_get_reuseaddr(lua_State *L, p_socket ps);
@@ -48,10 +60,18 @@ int opt_get_reuseaddr(lua_State *L, p_socket ps);
 int opt_get_ip_multicast_loop(lua_State *L, p_socket ps);
 int opt_get_ip_multicast_if(lua_State *L, p_socket ps);
 int opt_get_error(lua_State *L, p_socket ps);
+#ifdef IPV6_MULTICAST_LOOP
 int opt_get_ip6_multicast_loop(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_MULTICAST_HOPS
 int opt_get_ip6_multicast_hops(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_UNICAST_HOPS
 int opt_get_ip6_unicast_hops(lua_State *L, p_socket ps);
+#endif
+#ifdef IPV6_V6ONLY
 int opt_get_ip6_v6only(lua_State *L, p_socket ps); 
+#endif
 
 /* invokes the appropriate option handler */
 int opt_meth_setoption(lua_State *L, p_opt opt, p_socket ps);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -81,7 +81,9 @@ static t_opt optset[] = {
     {"keepalive",   opt_set_keepalive},
     {"reuseaddr",   opt_set_reuseaddr},
     {"tcp-nodelay", opt_set_tcp_nodelay},
+#ifdef IPV6_V6ONLY
     {"ipv6-v6only", opt_set_ip6_v6only},
+#endif
     {"linger",      opt_set_linger},
     {NULL,          NULL}
 };
@@ -366,11 +368,13 @@ static int tcp_create(lua_State *L, int family) {
         auxiliar_setclass(L, "tcp{master}", -1);
         /* initialize remaining structure fields */
         socket_setnonblocking(&sock);
+#ifdef IPV6_V6ONLY
         if (family == PF_INET6) {
             int yes = 1;
             setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                 (void *)&yes, sizeof(yes));
         }
+#endif
         tcp->sock = sock;
         io_init(&tcp->io, (p_send) socket_send, (p_recv) socket_recv,
                 (p_error) socket_ioerror, &tcp->sock);

--- a/src/udp.c
+++ b/src/udp.c
@@ -78,12 +78,22 @@ static t_opt optset[] = {
     {"ip-multicast-loop",    opt_set_ip_multicast_loop},
     {"ip-add-membership",    opt_set_ip_add_membership},
     {"ip-drop-membership",   opt_set_ip_drop_membersip},
+#ifdef IPV6_UNICAST_HOPS
     {"ipv6-unicast-hops",    opt_set_ip6_unicast_hops},
     {"ipv6-multicast-hops",  opt_set_ip6_unicast_hops},
+#endif
+#ifdef IPV6_MULTICAST_LOOP
     {"ipv6-multicast-loop",  opt_set_ip6_multicast_loop},
+#endif
+#ifdef IPV6_ADD_MEMBERSHIP
     {"ipv6-add-membership",  opt_set_ip6_add_membership},
+#endif
+#ifdef IPV6_DROP_MEMBERSHIP
     {"ipv6-drop-membership", opt_set_ip6_drop_membersip},
+#endif
+#ifdef IPV6_V6ONLY
     {"ipv6-v6only",          opt_set_ip6_v6only},
+#endif
     {NULL,                   NULL}
 };
 
@@ -92,10 +102,16 @@ static t_opt optget[] = {
     {"ip-multicast-if",      opt_get_ip_multicast_if},
     {"ip-multicast-loop",    opt_get_ip_multicast_loop},
     {"error",                opt_get_error},
+#ifdef IPV6_UNICAST_HOPS
     {"ipv6-unicast-hops",    opt_get_ip6_unicast_hops},
     {"ipv6-multicast-hops",  opt_get_ip6_unicast_hops},
+#endif
+#ifdef IPV6_MULTICAST_LOOP
     {"ipv6-multicast-loop",  opt_get_ip6_multicast_loop},
+#endif
+#ifdef IPV6_V6ONLY
     {"ipv6-v6only",          opt_get_ip6_v6only},
+#endif
     {NULL,                   NULL}
 };
 
@@ -416,11 +432,13 @@ static int udp_create(lua_State *L, int family) {
         auxiliar_setclass(L, "udp{unconnected}", -1);
         /* initialize remaining structure fields */
         socket_setnonblocking(&sock);
+#ifdef IPV6_V6ONLY
         if (family == PF_INET6) {
             int yes = 1;
             setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                 (void *)&yes, sizeof(yes));
         }
+#endif
         udp->sock = sock;
         timeout_init(&udp->tm, -1, -1);
         udp->family = family;


### PR DESCRIPTION
with [buildroot](http://buildroot.net/), we use various C libraries, for example [uClibc](http://www.uclibc.org/) which could be compiled with or without IPv6.

this commit solves this build issue : http://autobuild.buildroot.net/results/698/6989e71bf50946d62b696dbe07e8f00679b6aad9/build-end.log
