### PR TITLE
Generate headers before proxy changes host and port

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -247,10 +247,10 @@ local function adjustrequest(reqt)
         "invalid host '" .. base.tostring(nreqt.host) .. "'")
     -- compute uri if user hasn't overriden
     nreqt.uri = reqt.uri or adjusturi(nreqt)
-    -- ajust host and port if there is a proxy
-    nreqt.host, nreqt.port = adjustproxy(nreqt)
     -- adjust headers in request
     nreqt.headers = adjustheaders(nreqt)
+    -- ajust host and port if there is a proxy
+    nreqt.host, nreqt.port = adjustproxy(nreqt)
     return nreqt
 end
 

--- a/src/http.lua
+++ b/src/http.lua
@@ -222,6 +222,15 @@ local function adjustheaders(reqt)
         lower["authorization"] = 
             "Basic " ..  (mime.b64(reqt.user .. ":" .. reqt.password))
     end
+    -- if we have proxy authentication information, pass it along
+    local proxy = reqt.proxy or _M.PROXY
+    if proxy then
+        proxy = url.parse(proxy)
+        if proxy.user and proxy.password then
+            lower["proxy-authorization"] = 
+                "Basic " ..  (mime.b64(proxy.user .. ":" .. proxy.password))
+        end
+    end
     -- override with user headers
     for i,v in base.pairs(reqt.headers or lower) do
         lower[string.lower(i)] = v


### PR DESCRIPTION
Currently tests show that the code sends proxy info in the Host header. This can affect tomcat as it uses this information when generating pages. Test example of the header being sent out:
GET http://gato-public-st.tr.txstate.edu:80/testing-site/tests/redirect-pages/redirect-local.html HTTP/1.1
Host: 127.0.0.1:3128
TE: trailers
Connection: close, TE
User-Agent: lua 5.1, autotest

We can changed the order where the proxy updates the host and port after the headers are generated; so the actual host and port that we want to send would be put into the header. Test example of the header being sent out when we run adjustheaders before adjustproxy:
GET http://gato-public-st.tr.txstate.edu:80/testing-site/tests/redirect-pages/redirect-local.html HTTP/1.1
Host: gato-public-st.tr.txstate.edu:80
TE: trailers
Connection: close, TE
User-Agent: lua 5.1, autotest