### PR TITLE
src/usocket: Do not setblocking on destory;

### DIFF
--- a/src/usocket.c
+++ b/src/usocket.c
@@ -92,7 +92,6 @@ int socket_close(void) {
 \*-------------------------------------------------------------------------*/
 void socket_destroy(p_socket ps) {
     if (*ps != SOCKET_INVALID) {
-        socket_setblocking(ps);
         close(*ps);
         *ps = SOCKET_INVALID;
     }


### PR DESCRIPTION
This results in unexpected behaviour if the socket has been `dup()`d, as O_NONBLOCK is shared.
Close is always 'blocking' anyway on unix systems

See https://github.com/wahern/cqueues/issues/13 for an example use case

I have not done the same for windows (src/wsocket.c) as `closesocket()` can have non-blocking behaviour.
see http://msdn.microsoft.com/en-us/library/windows/desktop/ms737582(v=vs.85).aspx
