### PR TITLE
src/usocket: Do not setblocking on destroy;

### DIFF
--- a/src/usocket.c
+++ b/src/usocket.c
@@ -139,9 +139,7 @@ int socket_bind(p_socket ps, SA *addr, socklen_t len) {
 \*-------------------------------------------------------------------------*/
 int socket_listen(p_socket ps, int backlog) {
     int err = IO_DONE; 
-    socket_setblocking(ps);
     if (listen(*ps, backlog)) err = errno; 
-    socket_setnonblocking(ps);
     return err;
 }
 
@@ -149,9 +147,7 @@ int socket_listen(p_socket ps, int backlog) {
 * 
 \*-------------------------------------------------------------------------*/
 void socket_shutdown(p_socket ps, int how) {
-    socket_setblocking(ps);
     shutdown(*ps, how);
-    socket_setnonblocking(ps);
 }
 
 /*-------------------------------------------------------------------------*\


### PR DESCRIPTION
This results in unexpected behaviour if the socket has been `dup()`d, as O_NONBLOCK is shared.
Close is always 'blocking' anyway (on unix systems)

See https://github.com/wahern/cqueues/issues/13 for an example use case

I have not done the same for windows (src/wsocket.c) as `closesocket()` can have non-blocking behaviour.
see http://msdn.microsoft.com/en-us/library/windows/desktop/ms737582(v=vs.85).aspx
