### PR TITLE
Updated ftp and http methods for better async support

### DIFF
--- a/doc/ftp.html
+++ b/doc/ftp.html
@@ -95,7 +95,7 @@ the FTP module:
 <!-- ftp.get ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
 <p class=name id=get>
-ftp.<b>get(</b>url<b>)</b><br>
+ftp.<b>get(</b>url [, create]<b>)</b><br>
 ftp.<b>get{</b><br>
 &nbsp;&nbsp;host = <i>string</i>,<br>
 &nbsp;&nbsp;sink = <i>LTN12 sink</i>,<br>
@@ -114,7 +114,10 @@ ftp.<b>get{</b><br>
 The <tt>get</tt> function has two forms. The simple form has fixed
 functionality: it downloads the contents of a URL and returns it as a
 string. The generic form allows a <em>lot</em> more control, as explained
-below.
+below. The <tt>create</tt> parameter is only used in the string form,
+and will be used as alternative for <a href=tcp.html#socket.tcp><tt>socket.tcp</tt></a>
+if it is provided. In the advanced form <tt>create</tt> has to be specified
+in the arguments table.
 </p>
 
 <p class=parameters>
@@ -180,7 +183,7 @@ end
 <!-- put ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
 <p class=name id=put>
-ftp.<b>put(</b>url, content<b>)</b><br>
+ftp.<b>put(</b>url, content [, create]<b>)</b><br>
 ftp.<b>put{</b><br>
 &nbsp;&nbsp;host = <i>string</i>,<br>
 &nbsp;&nbsp;source = <i>LTN12 sink</i>,<br>
@@ -198,7 +201,11 @@ ftp.<b>put{</b><br>
 <p class=description>
 The <tt>put</tt> function has two forms. The simple form has fixed
 functionality: it uploads a string of content into a URL. The generic form
-allows a <em>lot</em> more control, as explained below.  
+allows a <em>lot</em> more control, as explained below. The <tt>create</tt> 
+parameter is only used in the string form, and will be used as alternative 
+for <a href=tcp.html#socket.tcp><tt>socket.tcp</tt></a> if it is provided. 
+In the advanced form <tt>create</tt> has to be specified in the arguments 
+table.
 </p>
 
 <p class=parameters>

--- a/doc/http.html
+++ b/doc/http.html
@@ -122,7 +122,7 @@ the HTTP module:
 <!-- http.request ++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
 <p class=name id="request">
-http.<b>request(</b>url [, body]<b>)</b><br>
+http.<b>request(</b>url [, body [, create]]<b>)</b><br>
 http.<b>request{</b><br>
 &nbsp;&nbsp;url = <i>string</i>,<br>
 &nbsp;&nbsp;[sink = <i>LTN12 sink</i>,]<br>
@@ -148,7 +148,9 @@ If the first argument of the <tt>request</tt> function is a string, it
 should be an <tt>url</tt>. In that case, if a <tt>body</tt>
 is provided as a string, the function will perform a <tt>POST</tt> method
 in the <tt>url</tt>. Otherwise, it performs a <tt>GET</tt> in the
-<tt>url</tt> 
+<tt>url</tt>. The <tt>create</tt> parameter is only used in the string form,
+and will be used as alternative for <a href=tcp.html#socket.tcp><tt>socket.tcp</tt></a>
+if it is provided.
 </p>
 
 <p class=parameters>

--- a/src/ftp.lua
+++ b/src/ftp.lua
@@ -232,14 +232,15 @@ local function parse(u)
     return t
 end
 
-local function sput(u, body)
+local function sput(u, body, create)
     local putt = parse(u)
     putt.source = ltn12.source.string(body)
+    putt.create = create
     return tput(putt)
 end
 
-_M.put = socket.protect(function(putt, body)
-    if base.type(putt) == "string" then return sput(putt, body)
+_M.put = socket.protect(function(putt, body, create)
+    if base.type(putt) == "string" then return sput(putt, body, create)
     else return tput(putt) end
 end)
 
@@ -256,10 +257,11 @@ local function tget(gett)
     return f:close()
 end
 
-local function sget(u)
+local function sget(u, create)
     local gett = parse(u)
     local t = {}
     gett.sink = ltn12.sink.table(t)
+    gett.create = create
     tget(gett)
     return table.concat(t)
 end
@@ -277,8 +279,8 @@ _M.command = socket.protect(function(cmdt)
     return f:close()
 end)
 
-_M.get = socket.protect(function(gett)
-    if base.type(gett) == "string" then return sget(gett)
+_M.get = socket.protect(function(gett, create)
+    if base.type(gett) == "string" then return sget(gett, create)
     else return tget(gett) end
 end)
 

--- a/src/http.lua
+++ b/src/http.lua
@@ -329,11 +329,12 @@ end
     return 1, code, headers, status
 end
 
-local function srequest(u, b)
+local function srequest(u, b, create)
     local t = {}
     local reqt = {
         url = u,
-        sink = ltn12.sink.table(t)
+        sink = ltn12.sink.table(t),
+        create = create,
     }
     if b then
         reqt.source = ltn12.source.string(b)
@@ -347,8 +348,8 @@ local function srequest(u, b)
     return table.concat(t), code, headers, status
 end
 
-_M.request = socket.protect(function(reqt, body)
-    if base.type(reqt) == "string" then return srequest(reqt, body)
+_M.request = socket.protect(function(reqt, body, create)
+    if base.type(reqt) == "string" then return srequest(reqt, body, create)
     else return trequest(reqt) end
 end)
 


### PR DESCRIPTION
If wrapping the `http` and `ftp` code for async support, not being able to pass `create` to the simple string based form of the methods, severly complicates wrapping it.

A large amount of code must be copied to create async behaviour. With this change it will be reduced to just a few lines and no redundant/duplicate code. See https://github.com/Tieske/copas/blob/671891f9e567dbd679c635f06174687df9e182ed/src/copas/copas/ftp.lua for the current `ftp.lua` async wrapper code.

for the record; change is fully backward compatible, not breaking.