### PR TITLE
Added missing options for UDP getoption.

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -105,9 +105,19 @@ int opt_set_dontroute(lua_State *L, p_socket ps)
     return opt_setboolean(L, ps, SOL_SOCKET, SO_DONTROUTE);
 }
 
+int opt_get_dontroute(lua_State *L, p_socket ps)
+{
+    return opt_getboolean(L, ps, SOL_SOCKET, SO_DONTROUTE);
+}
+
 int opt_set_broadcast(lua_State *L, p_socket ps)
 {
     return opt_setboolean(L, ps, SOL_SOCKET, SO_BROADCAST);
+}
+
+int opt_get_broadcast(lua_State *L, p_socket ps)
+{
+    return opt_getboolean(L, ps, SOL_SOCKET, SO_BROADCAST);
 }
 
 int opt_set_ip6_unicast_hops(lua_State *L, p_socket ps)

--- a/src/options.h
+++ b/src/options.h
@@ -40,11 +40,12 @@ int opt_set_ip6_drop_membersip(lua_State *L, p_socket ps);
 int opt_set_ip6_v6only(lua_State *L, p_socket ps);
 
 /* supported options for getoption */
+int opt_get_dontroute(lua_State *L, p_socket ps);
+int opt_get_broadcast(lua_State *L, p_socket ps);
 int opt_get_reuseaddr(lua_State *L, p_socket ps);
 int opt_get_tcp_nodelay(lua_State *L, p_socket ps);
 int opt_get_keepalive(lua_State *L, p_socket ps);
 int opt_get_linger(lua_State *L, p_socket ps);
-int opt_get_reuseaddr(lua_State *L, p_socket ps);
 int opt_get_ip_multicast_loop(lua_State *L, p_socket ps);
 int opt_get_ip_multicast_if(lua_State *L, p_socket ps);
 int opt_get_error(lua_State *L, p_socket ps);

--- a/src/udp.c
+++ b/src/udp.c
@@ -89,6 +89,10 @@ static t_opt optset[] = {
 
 /* socket options for getoption */
 static t_opt optget[] = {
+    {"dontroute",            opt_get_dontroute},
+    {"broadcast",            opt_get_broadcast},
+    {"reuseaddr",            opt_get_reuseaddr},
+    {"reuseport",            opt_get_reuseport},
     {"ip-multicast-if",      opt_get_ip_multicast_if},
     {"ip-multicast-loop",    opt_get_ip_multicast_loop},
     {"error",                opt_get_error},


### PR DESCRIPTION
Documentation says "dontroute", "broadcast", "reuseaddr", and
"reuseport" are supported as arguments to udp:getoption(), however their
implementations were missing.

```
local udp = socket.udp()
assert( udp:setoption("broadcast", true) )
print( udp:getoption("broadcast") )
```