### PR TITLE
Fix error in ltn12 under Lua 5.3

### DIFF
--- a/src/ltn12.lua
+++ b/src/ltn12.lua
@@ -43,7 +43,7 @@ end
 -- (thanks to Wim Couwenberg)
 function filter.chain(...)
     local arg = {...}
-    local n = select('#',...)
+    local n = base.select('#',...)
     local top, index = 1, 1
     local retry = ""
     return function(chunk)

--- a/src/ltn12.lua
+++ b/src/ltn12.lua
@@ -9,6 +9,7 @@
 -----------------------------------------------------------------------------
 local string = require("string")
 local table = require("table")
+local unpack = unpack or table.unpack
 local base = _G
 local _M = {}
 if module then -- heuristic for exporting a global package table

--- a/src/mbox.lua
+++ b/src/mbox.lua
@@ -61,7 +61,7 @@ function _M.parse_from(from)
 end
 
 function _M.split_mbox(mbox_s)
-    mbox = {}
+    local mbox = {}
     mbox_s = string.gsub(mbox_s, "\r\n", "\n") .."\n\nFrom \n"
     local nj, i, j = 1, 1, 1
     while 1 do

--- a/src/tp.lua
+++ b/src/tp.lua
@@ -74,7 +74,7 @@ function metat.__index:command(cmd, arg)
 end
 
 function metat.__index:sink(snk, pat)
-    local chunk, err = c:receive(pat)
+    local chunk, err = self.c:receive(pat)
     return snk(chunk, err)
 end
 

--- a/src/url.lua
+++ b/src/url.lua
@@ -219,6 +219,7 @@ end
 --   corresponding absolute url
 -----------------------------------------------------------------------------
 function _M.absolute(base_url, relative_url)
+    local base_parsed
     if base.type(base_url) == "table" then
         base_parsed = base_url
         base_url = _M.build(base_parsed)


### PR DESCRIPTION
`unpack` became `table.unpack` in Lua 5.2, not available with default compilation flags in Lua 5.3.