### PR TITLE
URL-decode user password before adding to authorization header.

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -222,7 +222,8 @@ local function adjustheaders(reqt)
     -- if we have authentication information, pass it along
     if reqt.user and reqt.password then
         lower["authorization"] =
-            "Basic " ..  (mime.b64(reqt.user .. ":" .. reqt.password))
+            "Basic " ..  (mime.b64(reqt.user .. ":" ..
+		url.unescape(reqt.password)))
     end
     -- if we have proxy authentication information, pass it along
     local proxy = reqt.proxy or _M.PROXY

--- a/src/url.lua
+++ b/src/url.lua
@@ -64,11 +64,11 @@ local function protect_segment(s)
 end
 
 -----------------------------------------------------------------------------
--- Encodes a string into its escaped hexadecimal representation
+-- Unencodes a escaped hexadecimal string into its binary representation
 -- Input
---   s: binary string to be encoded
+--   s: escaped hexadecimal string to be unencoded
 -- Returns
---   escaped representation of string binary
+--   unescaped binary representation of escaped hexadecimal  binary
 -----------------------------------------------------------------------------
 function _M.unescape(s)
     return (string.gsub(s, "%%(%x%x)", function(hex)


### PR DESCRIPTION
If a URL like `http://username:p%40ssword@server.com/` - where @ symbol in password is URL-encoded - is passed to `http.request()` method, the password is added to Authorization header as it is, leading to failed authentication response from server. Decoding the password just before adding it to the header resolves this issue. That is what this pull request does.

This should also resolve same problem in LuaSec's `https.request()` function will depends upon LuaSocket.