### PR TITLE
Handle port as number in socket.url.build

### DIFF
--- a/src/url.lua
+++ b/src/url.lua
@@ -193,7 +193,13 @@ function _M.build(parsed)
         if string.find(authority, ":") then -- IPv6?
             authority = "[" .. authority .. "]"
         end
-        if parsed.port then authority = authority .. ":" .. parsed.port end
+        local port = parsed.port
+        if port then
+            if type(port) == "number" then
+                port = string.format("%d", port)
+            end
+            authority = authority .. ":" .. port
+        end
         local userinfo = parsed.userinfo
         if parsed.user then
             userinfo = parsed.user


### PR DESCRIPTION
In particular, luasec passes port as number to socket.url.build.
Under Lua 5.3 this can lead to '.0' added to port when converting to
string (or an error if implicit conversions are disabled), use 'string.format("%d", port)' to avoid that.