### PR TITLE
Fix SMTP/FTP subsystem for case-sensitive file names

### DIFF
--- a/src/tp.lua
+++ b/src/tp.lua
@@ -73,7 +73,7 @@ function metat.__index:check(ok)
 end
 
 function metat.__index:command(cmd, arg)
-    cmd = string.upper(cmd)
+    cmd = string.find(cmd, " ") and string.upper(cmd:match("(.-)%s")) .. cmd:match(".-(%s.+)") or string.upper(cmd)
     if arg then
         return self.c:send(cmd .. " " .. arg.. "\r\n")
     else


### PR DESCRIPTION
Currently the *whole* command is made UPPERCASE, because some servers may refuse them otherwise, but by doing this you're breaking file names for case-sensitive filesystems (e.g. ext-family, the majority of the *nix servers).

Example: cmd argument equals "list /world/"
Result: "LIST /WORLD/" will be sent and the server will respond that "/WORLD/" directory doesn't exist, because lowercase ~= uppercase
This patch will fix it to return "LIST /world/" and the server will find the path on it's side.

Introduced in: https://github.com/diegonehab/luasocket/commit/bce60be30fe8e9c1b0eb33128c23c93d7bca5303#diff-52829881345969821da3e6b836f35bc5

PS: I hope the one-liner is okay.
PPS: I can't believe I've found such an old bug (yet at the expense of roughly 2 hours)