### PR TITLE
make protect_segment in url.lua rfc compliant

### DIFF
--- a/src/url.lua
+++ b/src/url.lua
@@ -49,7 +49,7 @@ local function make_set(t)
     return s
 end
 
--- these are allowed withing a path segment, along with alphanum
+-- these are allowed within a path segment, along with alphanum
 -- other characters must be escaped
 local segment_set = make_set {
     "-", "_", ".", "!", "~", "*", "'", "(",

--- a/src/url.lua
+++ b/src/url.lua
@@ -59,7 +59,7 @@ local segment_set = make_set {
 local function protect_segment(s)
     return string.gsub(s, "([^A-Za-z0-9_])", function (c)
         if segment_set[c] then return c
-        else return string.format("%%%02x", string.byte(c)) end
+        else return string.format("%%%02X", string.byte(c)) end
     end)
 end
 


### PR DESCRIPTION
percent-encode uppercase
see https://tools.ietf.org/html/rfc3986#section-6.2.2 :
"For all URIs, the hexadecimal digits within a percent-encoding
   triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore
   should be normalized to use uppercase letters for the digits A-F."