### PR TITLE
fix for Lua 5.3 built without number / string conversion

### DIFF
--- a/src/url.lua
+++ b/src/url.lua
@@ -193,7 +193,7 @@ function _M.build(parsed)
         if string.find(authority, ":") then -- IPv6?
             authority = "[" .. authority .. "]"
         end
-        if parsed.port then authority = authority .. ":" .. parsed.port end
+        if parsed.port then authority = authority .. ":" .. base.tostring(parsed.port) end
         local userinfo = parsed.userinfo
         if parsed.user then
             userinfo = parsed.user


### PR DESCRIPTION
This kind of Lua could be built with this command:
```
    hererocks --lua 5.3 --cflags="-DLUA_NOCVTN2S -DLUA_NOCVTS2N"
```