### PR TITLE
Fix include directory on Makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -48,7 +48,7 @@ LDIR_macosx?=share/lua/$(LUAV)
 # /usr/local/include/lua$(LUAV)
 # where lua headers are found for linux builds
 LUAINC_linux_base?=/usr/include
-LUAINC_linux?=$(LUAINC_linux_base)/lua/$(LUAV)
+LUAINC_linux?=$(LUAINC_linux_base)/lua$(LUAV)
 LUAPREFIX_linux?=/usr/local
 CDIR_linux?=lib/lua/$(LUAV)
 LDIR_linux?=share/lua/$(LUAV)


### PR DESCRIPTION
The lua.h file is found under /usr/include/lua5.1/ and not under
/usr/include/lua/5.1/ on my Ubuntu linux machine (X64 and PPC64le
architectures).