### PR TITLE
fix buffer overflow in opt_meth_setoption

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -3,6 +3,7 @@
 * LuaSocket toolkit
 \*=========================================================================*/
 #include <string.h>
+#include <stdlib.h>
 
 #include "lauxlib.h"
 
@@ -37,9 +38,10 @@ int opt_meth_setoption(lua_State *L, p_opt opt, p_socket ps)
     while (opt->name && strcmp(name, opt->name))
         opt++;
     if (!opt->func) {
-        char msg[45];
+        char* msg = malloc(30+strlen(name));
         sprintf(msg, "unsupported option `%.35s'", name);
         luaL_argerror(L, 2, msg);
+        free(msg);
     }
     return opt->func(L, ps);
 }


### PR DESCRIPTION
PoC trigger:
c=socket.connect('google.com',80)
c.setoption(c,'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')