### PR TITLE
mime.lua: Obsolete require("io")

### DIFF
--- a/src/mime.lua
+++ b/src/mime.lua
@@ -10,7 +10,6 @@
 local base = _G
 local ltn12 = require("ltn12")
 local mime = require("mime.core")
-local io = require("io")
 local string = require("string")
 local _M = mime
 


### PR DESCRIPTION
The `io` package is included but never used.