### PR TITLE
src/options.c: minor buffer size issue detected by GCC 7

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -37,7 +37,7 @@ int opt_meth_setoption(lua_State *L, p_opt opt, p_socket ps)
     while (opt->name && strcmp(name, opt->name))
         opt++;
     if (!opt->func) {
-        char msg[45];
+        char msg[57];
         sprintf(msg, "unsupported option `%.35s'", name);
         luaL_argerror(L, 2, msg);
     }
@@ -50,7 +50,7 @@ int opt_meth_getoption(lua_State *L, p_opt opt, p_socket ps)
     while (opt->name && strcmp(name, opt->name))
         opt++;
     if (!opt->func) {
-        char msg[45];
+        char msg[57];
         sprintf(msg, "unsupported option `%.35s'", name);
         luaL_argerror(L, 2, msg);
     }


### PR DESCRIPTION
Two small temporary buffers in src/options.c were declared a bit too small to accommodate the maximum calculable size of the string that could result from sprintf(), as detected by -Wstringpop-overflow.  It turns out that 57 is the smallest number meeting this critera, silencing the GCC warning and (possibly) preventing other unpredictable or incorrect behavior.