### PR TITLE
EAI_OVERFLOW, AI_NUMERICSERV: put behind #ifdef

### DIFF
--- a/src/udp.c
+++ b/src/udp.c
@@ -188,7 +188,10 @@ static int meth_sendto(lua_State *L) {
     memset(&aihint, 0, sizeof(aihint));
     aihint.ai_family = udp->family;
     aihint.ai_socktype = SOCK_DGRAM;
-    aihint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+    aihint.ai_flags = AI_NUMERICHOST;
+#ifdef AI_NUMERICSERV
+    aihint.ai_flags |= AI_NUMERICSERV;
+#endif
     err = getaddrinfo(ip, port, &aihint, &ai);
 	if (err) {
         lua_pushnil(L);

--- a/src/usocket.c
+++ b/src/usocket.c
@@ -440,7 +440,9 @@ LUASOCKET_PRIVATE const char *socket_gaistrerror(int err) {
         case EAI_FAMILY: return PIE_FAMILY;
         case EAI_MEMORY: return PIE_MEMORY;
         case EAI_NONAME: return PIE_NONAME;
+#ifdef EAI_OVERFLOW
         case EAI_OVERFLOW: return PIE_OVERFLOW;
+#endif
 #ifdef EAI_PROTOCOL
         case EAI_PROTOCOL: return PIE_PROTOCOL;
 #endif


### PR DESCRIPTION
It may not be defined on some systems.

See some other comments in #242

There's a remaining issue that `AI_NUMERICSERV` from `src/udp.c` is also not defined. Not sure how to fix that one other than also commenting it out.