### PR TITLE
Fixed an issue that was mistaken for HTTP 0.9 when timeout

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -147,10 +147,15 @@ function metat.__index:sendbody(headers, source, step)
 end
 
 function metat.__index:receivestatusline()
-    local status = self.try(self.c:receive(5))
+    local status,ec = self.try(self.c:receive(5))
     -- identify HTTP/0.9 responses, which do not contain a status line
     -- this is just a heuristic, but is what the RFC recommends
-    if status ~= "HTTP/" then return nil, status end
+    if status ~= "HTTP/" then
+        if ec == "timeout" then
+            return 408
+        end 
+        return nil, status 
+    end
     -- otherwise proceed reading a status line
     status = self.try(self.c:receive("*l", status))
     local code = socket.skip(2, string.find(status, "HTTP/%d*%.%d* (%d%d%d)"))
@@ -325,6 +330,8 @@ end
     if not code then
         h:receive09body(status, nreqt.sink, nreqt.step)
         return 1, 200
+    elseif code == 408 then
+        return 1, code
     end
     local headers
     -- ignore any 100-continue messages


### PR DESCRIPTION
In the case of a very poor network, the connection times out and could'n get the status, then it thinks it is HTTP 0.9 and then executes receive09body function, causing the application to crash under IOS