### PR TITLE
Update auxiliar.c to use luaL_testudata (#249), now with Lua 5.1 compatibility

### DIFF
--- a/src/auxiliar.c
+++ b/src/auxiliar.c
@@ -143,7 +143,7 @@ void *auxiliar_getgroupudata(lua_State *L, const char *groupname, int objidx) {
 * otherwise
 \*-------------------------------------------------------------------------*/
 void *auxiliar_getclassudata(lua_State *L, const char *classname, int objidx) {
-    return luaL_checkudata(L, objidx, classname);
+    return luaL_testudata(L, objidx, classname);
 }
 
 /*-------------------------------------------------------------------------*\

--- a/src/compat.c
+++ b/src/compat.c
@@ -16,4 +16,22 @@ void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
   }
   lua_pop(L, nup);  /* remove upvalues */
 }
+
+/*
+** Duplicated from Lua 5.2
+*/
+void *luaL_testudata (lua_State *L, int ud, const char *tname) {
+  void *p = lua_touserdata(L, ud);
+  if (p != NULL) {  /* value is a userdata? */
+    if (lua_getmetatable(L, ud)) {  /* does it have a metatable? */
+      luaL_getmetatable(L, tname);  /* get correct metatable */
+      if (!lua_rawequal(L, -1, -2))  /* not the same? */
+        p = NULL;  /* value is a userdata with wrong metatable */
+      lua_pop(L, 2);  /* remove both metatables */
+      return p;
+    }
+  }
+  return NULL;  /* value is not a userdata with a metatable */
+}
+
 #endif

--- a/src/compat.h
+++ b/src/compat.h
@@ -6,6 +6,7 @@
 
 #if LUA_VERSION_NUM==501
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
+void *luaL_testudata ( lua_State *L, int arg, const char *tname);
 #endif
 
 #endif


### PR DESCRIPTION
Provides PR #249 with a copy of `luaL_testudata` for the Lua 5.1 build case.