### PR TITLE
http.lua: if default for scheme, omit port number in "Host:" header

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -27,9 +27,13 @@ _M.TIMEOUT = 60
 _M.USERAGENT = socket._VERSION
 
 -- supported schemes
-local SCHEMES = { ["http"] = true }
--- default port for document retrieval
-local PORT = 80
+local SCHEMES = {
+    http = { port = 80 }
+    , https = { port = 443 }}
+
+-- default scheme and port for document retrieval
+local SCHEME = 'http'
+local PORT = SCHEMES[SCHEME].port
 
 -----------------------------------------------------------------------------
 -- Reads MIME headers from a connection, unfolding where needed
@@ -212,10 +216,14 @@ end
 
 local function adjustheaders(reqt)
     -- default headers
-    local host = string.gsub(reqt.authority, "^.-@", "")
+    local headhost = reqt.host
+    local headport = tostring(reqt.port)
+    local schemeport = tostring(SCHEMES[reqt.scheme].port)
+    if headport ~= schemeport then
+        headhost = headhost .. ':' .. headport end
     local lower = {
         ["user-agent"] = _M.USERAGENT,
-        ["host"] = host,
+        ["host"] = headhost,
         ["connection"] = "close, TE",
         ["te"] = "trailers"
     }
@@ -246,7 +254,7 @@ local default = {
     host = "",
     port = PORT,
     path ="/",
-    scheme = "http"
+    scheme = SCHEME
 }
 
 local function adjustrequest(reqt)


### PR DESCRIPTION
In [luasec #117](https://github.com/brunoos/luasec/issues/117), it was discovered that luasocket's [http.lua](https://github.com/diegonehab/luasocket/blob/288219fd6b53ce2e709745c9918aa4c4b7f715c9/src/http.lua#L215) fails to omit the port number in the `Host:` request header when it is the default for the scheme.  While that's not improper, it is indeed rather unusual, and was problematically unexpected by at least one high-profile server in the wild.

With this change, we now only include the port number in the `Host:` header if it is not the default for the scheme, using knowledge of the default ports of schemes for which we are known to be invoked, i.e. `http` and `https`.

At the same time, compliance with [RFC 2616](https://tools.ietf.org/html/rfc2616#section-14.23) is now improved by constructing the `Host:` header using just the `host` and `port` strings as found by parsing.  The previous use of `authority` was improper, since it can also contain `userinfo` data (per [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.2)).