### PR TITLE
Fix static linking problem with LuaJIT

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -5,6 +5,8 @@
 #include "lauxlib.h"
 
 #if LUA_VERSION_NUM==501
+#define luaL_setfuncs socket_setfuncs
+#define luaL_testudata socket_testudata
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
 void *luaL_testudata ( lua_State *L, int arg, const char *tname);
 #endif


### PR DESCRIPTION
LuaJIT and LuaSocket both define new Lua APIs from Lua 5.2 (in
particular `luaL_setfuncs` and `luaL_testudata`). When linking both
statically, the one definition rule strikes and linking fails. This
commit fixes the issue by renaming the LuaSocket versions of those
functions behind the scenes using the C preprocessor.

Closes #214