### PR TITLE
Allow overriding of hard-coded redirect limit

### DIFF
--- a/doc/http.html
+++ b/doc/http.html
@@ -135,7 +135,8 @@ http.<b>request{</b><br>
 &nbsp;&nbsp;[step = <i>LTN12 pump step</i>,]<br>
 &nbsp;&nbsp;[proxy = <i>string</i>,]<br>
 &nbsp;&nbsp;[redirect = <i>boolean</i>,]<br>
-&nbsp;&nbsp;[create = <i>function</i>]<br>
+&nbsp;&nbsp;[create = <i>function</i>,]<br>
+&nbsp;&nbsp;[maxredirects = <i>number</i>]<br>
 <b>}</b>
 </p>
 
@@ -185,6 +186,7 @@ Defaults to the LTN12 <tt>pump.step</tt> function.
 function from  automatically following 301 or 302 server redirect messages; 
 <li><tt>create</tt>: An optional function to be used instead of
 <a href=tcp.html#socket.tcp><tt>socket.tcp</tt></a> when the communications socket is created. 
+<li><tt>maxredirects</tt>: An optional number specifying the maximum number of redirects to follow.  Defaults to <tt>5</tt> if not specified.  A boolean <tt>false</tt> value means no maximum (unlimited).
 </ul>
 
 <p class=return>
@@ -324,8 +326,8 @@ r, c = http.request {
 </p>
 <p>
 <small>
-Last modified by Diego Nehab on <br>
-Thu Apr 20 00:25:26 EDT 2006
+Last modified by Eric Westbrook on <br>
+Sat Feb 23 19:09:42 UTC 2019
 </small>
 </p>
 </center>

--- a/src/http.lua
+++ b/src/http.lua
@@ -277,7 +277,9 @@ local function shouldredirect(reqt, code, headers)
     return (reqt.redirect ~= false) and
            (code == 301 or code == 302 or code == 303 or code == 307) and
            (not reqt.method or reqt.method == "GET" or reqt.method == "HEAD")
-           and (not reqt.nredirects or reqt.nredirects < 5)
+        and ((false == reqt.maxredirects)
+                or ((reqt.nredirects or 0)
+                        < (reqt.maxredirects or 5)))
 end
 
 local function shouldreceivebody(reqt, code)
@@ -299,6 +301,7 @@ local trequest, tredirect
         sink = reqt.sink,
         headers = reqt.headers,
         proxy = reqt.proxy,
+        maxredirects = reqt.maxredirects,
         nredirects = (reqt.nredirects or 0) + 1,
         create = reqt.create
     }


### PR DESCRIPTION
If a `maxredirects` field is present in input table to `http.request`, it specifies an override to the hard-coded limit of `5` redirects, with a value of `false` signifying no limit.  Documentation updated.