### PR TITLE
add cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,10 @@ if(WIN32)
 	add_definitions(-D_WIN32_WINNT=0x0600) ##should be this or the next two for working on XP
 	#add_definitions(-D_WIN32_WINNT=0x0501)
 	#add_definitions(-DLUASOCKET_INET_PTON)
-	add_definitions("-DLUASOCKET_API=__declspec(dllexport)")
-	add_definitions("-DMIME_API=__declspec(dllexport)")
 	set(LUASOCKET_LINK  wsock32 ws2_32 )
 	set(POSTN dll)
 else()
 	list(REMOVE_ITEM socket_src ./src/wsocket.c) 
-	add_definitions("-DLUASOCKET_API=__attribute__((visibility(default)))")
-	add_definitions("-DMIME_API=__attribute__((visibility(default)))")
 	set(POSTN so)
 endif(WIN32)
 
@@ -25,7 +21,12 @@ endif(WIN32)
 INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
 
 add_definitions(-DLUASOCKET_DEBUG)
-add_definitions(-DLUA_BUILD_AS_DLL -DLUA_LIB -DLUASOCKET_EXPORTS)
+
+if(WIN32)
+add_definitions(-DLUA_BUILD_AS_DLL -DLUA_LIB)
+endif()
+
+add_definitions( -DLUASOCKET_EXPORTS)
 
 add_library(socket SHARED ${socket_src})
 ADD_LIBRARY(mime SHARED ./src/mime.c ./src/compat.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,10 @@ cmake_minimum_required(VERSION 2.8)
 aux_source_directory(./src socket_src)
 list(REMOVE_ITEM socket_src ./src/mime.c)
 if(WIN32)
-	list(REMOVE_ITEM socket_src ./src/serial.c ./src/unix.c ./src/usocket.c)
-	add_definitions(-D_WIN32_WINNT=0x0501)
+	list(REMOVE_ITEM socket_src ./src/serial.c ./src/unix.c ./src/usocket.c ./src/unixdgram.c ./src/unixstream.c)
+	add_definitions(-D_WIN32_WINNT=0x0600) ##should be this or the next two for working on XP
+	#add_definitions(-D_WIN32_WINNT=0x0501)
+	#add_definitions(-DLUASOCKET_INET_PTON)
 	add_definitions("-DLUASOCKET_API=__declspec(dllexport)")
 	add_definitions("-DMIME_API=__declspec(dllexport)")
 	set(POSTN dll)
@@ -15,9 +17,7 @@ else()
 	add_definitions("-DMIME_API=__attribute__((visibility(default)))")
 	set(POSTN so)
 endif(WIN32)
-if(WIN32)#MINGW) and msvc
-	add_definitions(-DLUASOCKET_INET_PTON)
-endif()
+
 
 INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
 
@@ -26,12 +26,12 @@ add_definitions(-DLUA_BUILD_AS_DLL -DLUA_LIB -DLUASOCKET_EXPORTS)
 
 add_library(socket SHARED ${socket_src})
 ADD_LIBRARY(mime SHARED ./src/mime.c ./src/compat.c)
-#set_target_properties(socket PROPERTIES PREFIX "" OUTPUT_NAME core)
-#set_target_properties(mime PROPERTIES PREFIX "" OUTPUT_NAME core)
+
 if(MSVC)
 	set_target_properties(socket PROPERTIES PREFIX "lib")
 	set_target_properties(mime PROPERTIES PREFIX "lib")
 endif()
+
 TARGET_LINK_LIBRARIES(socket ${LUA_LIBRARY} wsock32 ws2_32 )
 TARGET_LINK_LIBRARIES(mime ${LUA_LIBRARY}) 
 
@@ -47,8 +47,7 @@ endif()
 ##cant use set_target_properties to rename because one overwrites the other so:
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libsocket.${POSTN} DESTINATION ${CDIR}/socket RENAME core.${POSTN})
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libmime.${POSTN} DESTINATION ${CDIR}/mime RENAME core.${POSTN})  
-#INSTALL(TARGETS socket RUNTIME DESTINATION ${CDIR}/socket)
-#INSTALL(TARGETS mime RUNTIME DESTINATION ${CDIR}/mime)
+
 install(DIRECTORY src/ DESTINATION ${LDIR}/socket
         FILES_MATCHING PATTERN "*.lua"
 		PATTERN ltn12.lua EXCLUDE 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 2.8)
 
 aux_source_directory(./src socket_src)
 list(REMOVE_ITEM socket_src ./src/mime.c)
+set(LUASOCKET_LINK)
 if(WIN32)
 	list(REMOVE_ITEM socket_src ./src/serial.c ./src/unix.c ./src/usocket.c ./src/unixdgram.c ./src/unixstream.c)
 	add_definitions(-D_WIN32_WINNT=0x0600) ##should be this or the next two for working on XP
@@ -11,8 +12,10 @@ if(WIN32)
 	#add_definitions(-DLUASOCKET_INET_PTON)
 	add_definitions("-DLUASOCKET_API=__declspec(dllexport)")
 	add_definitions("-DMIME_API=__declspec(dllexport)")
+	set(LUASOCKET_LINK  wsock32 ws2_32 )
 	set(POSTN dll)
 else()
+	list(REMOVE_ITEM socket_src ./src/wsocket.c) 
 	add_definitions("-DLUASOCKET_API=__attribute__((visibility(default)))")
 	add_definitions("-DMIME_API=__attribute__((visibility(default)))")
 	set(POSTN so)
@@ -32,7 +35,7 @@ if(MSVC)
 	set_target_properties(mime PROPERTIES PREFIX "lib")
 endif()
 
-TARGET_LINK_LIBRARIES(socket ${LUA_LIBRARY} wsock32 ws2_32 )
+TARGET_LINK_LIBRARIES(socket ${LUA_LIBRARY} ${LUASOCKET_LINK} )
 TARGET_LINK_LIBRARIES(mime ${LUA_LIBRARY}) 
 
 ######install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,57 @@
+PROJECT(luasocket C)
+cmake_minimum_required(VERSION 2.8)
+
+
+aux_source_directory(./src socket_src)
+list(REMOVE_ITEM socket_src ./src/mime.c)
+if(WIN32)
+	list(REMOVE_ITEM socket_src ./src/serial.c ./src/unix.c ./src/usocket.c)
+	add_definitions(-D_WIN32_WINNT=0x0501)
+	add_definitions("-DLUASOCKET_API=__declspec(dllexport)")
+	add_definitions("-DMIME_API=__declspec(dllexport)")
+	set(POSTN dll)
+else()
+	add_definitions("-DLUASOCKET_API=__attribute__((visibility(default)))")
+	add_definitions("-DMIME_API=__attribute__((visibility(default)))")
+	set(POSTN so)
+endif(WIN32)
+if(WIN32)#MINGW) and msvc
+	add_definitions(-DLUASOCKET_INET_PTON)
+endif()
+
+INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
+
+add_definitions(-DLUASOCKET_DEBUG)
+add_definitions(-DLUA_BUILD_AS_DLL -DLUA_LIB -DLUASOCKET_EXPORTS)
+
+add_library(socket SHARED ${socket_src})
+ADD_LIBRARY(mime SHARED ./src/mime.c ./src/compat.c)
+#set_target_properties(socket PROPERTIES PREFIX "" OUTPUT_NAME core)
+#set_target_properties(mime PROPERTIES PREFIX "" OUTPUT_NAME core)
+if(MSVC)
+	set_target_properties(socket PROPERTIES PREFIX "lib")
+	set_target_properties(mime PROPERTIES PREFIX "lib")
+endif()
+TARGET_LINK_LIBRARIES(socket ${LUA_LIBRARY} wsock32 ws2_32 )
+TARGET_LINK_LIBRARIES(mime ${LUA_LIBRARY}) 
+
+######install
+#set default LDIR and CDIR if not given
+if( NOT CDIR)
+	set(CDIR .)
+endif()
+if( NOT LDIR)
+	set(LDIR ./lua)
+endif()
+
+##cant use set_target_properties to rename because one overwrites the other so:
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libsocket.${POSTN} DESTINATION ${CDIR}/socket RENAME core.${POSTN})
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libmime.${POSTN} DESTINATION ${CDIR}/mime RENAME core.${POSTN})  
+#INSTALL(TARGETS socket RUNTIME DESTINATION ${CDIR}/socket)
+#INSTALL(TARGETS mime RUNTIME DESTINATION ${CDIR}/mime)
+install(DIRECTORY src/ DESTINATION ${LDIR}/socket
+        FILES_MATCHING PATTERN "*.lua"
+		PATTERN ltn12.lua EXCLUDE 
+		PATTERN socket.lua EXCLUDE
+		PATTERN mime.lua EXCLUDE)
+install(FILES ./src/socket.lua ./src/mime.lua ./src/ltn12.lua DESTINATION ${LDIR})


### PR DESCRIPTION
This is a cmake tested in mingw and nmake.
Only changes needed would be analogous to https://github.com/sonoro1234/luasocket/blob/cmakefor3_0/CMakeLists.txt#L8
to avoid compile not linux or not osx files (I am not sure which there are)

To test it just create a sibbling folder to luasocket repository folder and run
```
cmake  -G"Your desired generator"  -DCMAKE_BUILD_TYPE="Release"  -DLUA_INCLUDE_DIR="lua.h location" -DLUA_LIBRARY="lua library location" -DCMAKE_INSTALL_PREFIX="location of installation, generally where lua.exe is " ../luasocket
```

The list of available generators is in https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html

After it has finished generating just run

`make install` (for mingw32-w64 it would be `mingw32-make install`)

and thats all!!