### PR TITLE
fix test/tcp-getoptions

### DIFF
--- a/test/find-connect-limit
+++ b/test/find-connect-limit
@@ -10,7 +10,7 @@ ulimit -n
 You'll probably need to be root to do this.
 ]]
 
-require "socket"
+socket = require "socket"
 
 host = arg[1] or "google.com"
 port = arg[2] or 80

--- a/test/tcp-getoptions
+++ b/test/tcp-getoptions
@@ -1,6 +1,6 @@
 #!/usr/bin/env lua
 
-require"socket"
+local socket = require"socket"
 
 port = 8765
 

--- a/test/tcp-getoptions
+++ b/test/tcp-getoptions
@@ -4,18 +4,32 @@ local socket = require"socket"
 
 port = 8765
 
+function pcalltest(msg, o, opt)
+  local a = { pcall(o.getoption, o, opt) }
+  if a[1] then
+    print(msg, opt, unpack(a))
+  else
+    print(msg, opt, 'fail: ' .. a[2])
+  end
+end
+
 function options(o)
     print("options for", o)
 
     for _, opt in ipairs{
     		"keepalive", "reuseaddr",
      		"tcp-nodelay", "tcp-keepidle", "tcp-keepcnt", "tcp-keepintvl"} do
-        print("getoption", opt, o:getoption(opt))
+        pcalltest("getoption", o, opt)
     end
 
-    print("getoption", "linger",
-        "on", o:getoption("linger").on,
-        "timeout", o:getoption("linger").timeout)
+    r = o:getoption'linger'
+    if r then
+      print("getoption", "linger",
+            "on", r.on,
+            "timeout", r.timeout)
+    else
+      print("getoption", "linger", "no result")
+    end
 end
 
 local m = socket.tcp()

--- a/test/udp-zero-length-send
+++ b/test/udp-zero-length-send
@@ -1,4 +1,4 @@
-#!/usr/bin/lua
+#!/usr/bin/env lua
 
 --[[
 Show that luasocket returns an error message on zero-length UDP sends,
@@ -12,7 +12,7 @@ listening on lo, link-type EN10MB (Ethernet), capture size 65535 bytes
 
 ]]
 
-require"socket"
+socket = require"socket"
 
 s = assert(socket.udp())
 r = assert(socket.udp())

--- a/test/udp-zero-length-send-recv
+++ b/test/udp-zero-length-send-recv
@@ -1,4 +1,4 @@
-#!/usr/bin/lua
+#!/usr/bin/env lua
 
 --[[
 Show that luasocket returns an error message on zero-length UDP sends,
@@ -12,7 +12,7 @@ listening on lo, link-type EN10MB (Ethernet), capture size 65535 bytes
 
 ]]
 
-require"socket"
+socket = require"socket"
 
 s = assert(socket.udp())
 r = assert(socket.udp())


### PR DESCRIPTION
In response to #297.  Work in progress.

Adding `socket =` to `require"socket"` fixes the reported error, but now I see others.

```
$ ./tcp-getoptions
options for     tcp{master}: 0x7f8a92804a28
getoption       keepalive       nil     getsockopt failed
getoption       reuseaddr       nil     getsockopt failed
getoption       tcp-nodelay     nil     getsockopt failed
lua: ./tcp-getoptions:13: bad argument #1 to 'getoption' (unsupported option `tcp-keepidle')
stack traceback:
        [C]: in function 'getoption'
        ./tcp-getoptions:13: in function 'options'
        ./tcp-getoptions:23: in main chunk
        [C]: ?
```