### PR TITLE
Remove obsolete typedef from compatibility file

### DIFF
--- a/src/wsocket.h
+++ b/src/wsocket.h
@@ -11,7 +11,6 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-typedef int socklen_t;
 typedef SOCKADDR_STORAGE t_sockaddr_storage;
 typedef SOCKET t_socket;
 typedef t_socket *p_socket;


### PR DESCRIPTION
MinGWs `ws2tcpip.h` already defines `socklen_t`, making this redundant.
What's more, in a recent version of MinGW this has changed to `unsigned int`, breaking compatibility. See issue #302 

I *tried* looking through the git log to see if there was a reason for this being there, but all I could find was in `f3305405` it was added without a comment, under the commit message

> Compiles and runs on linux and windows, using DLLs!

That was in 2003 using who knows which version of MinGW 😖

Thus, I assume it is OK to just remove this typedef altogether, but it'd be nice if someone could actually confirm this (Ideally, clarify why this was added in the first place)