### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/installation.html
+++ b/doc/installation.html
@@ -79,6 +79,21 @@ distribution directory structure:</p>
 would be replaced by <tt>core.so</tt>.  
 </p>
 
+<p>
+Alternatively, you can build and install LuaSocket using vcpkg dependency manager:
+
+<pre class=example>
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install luasocket
+</pre>
+
+The luasocket port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please create an issue or pull request on the vcpkg repository.
+
+</p>
 <h3>Using LuaSocket</h3>
 
 <p> With the above setup, and an interpreter with shared library support,


### PR DESCRIPTION
LuaSocket is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build LuaSocket, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for LuaSocket and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.