### PR TITLE
Explicitly call gai_strerrorA (for Windows builds)

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -253,7 +253,7 @@ int inet_meth_getpeername(lua_State *L, p_socket ps, int family)
         port, sizeof(port), NI_NUMERICHOST | NI_NUMERICSERV);
     if (err) {
         lua_pushnil(L);
-        lua_pushstring(L, gai_strerror(err));
+        lua_pushstring(L, gai_strerrorA(err));
         return 2;
     }
     lua_pushstring(L, name);
@@ -286,7 +286,7 @@ int inet_meth_getsockname(lua_State *L, p_socket ps, int family)
 		name, INET6_ADDRSTRLEN, port, 6, NI_NUMERICHOST | NI_NUMERICSERV);
     if (err) {
         lua_pushnil(L);
-        lua_pushstring(L, gai_strerror(err));
+        lua_pushstring(L, gai_strerrorA(err));
         return 2;
     }
     lua_pushstring(L, name);

--- a/src/udp.c
+++ b/src/udp.c
@@ -191,7 +191,7 @@ static int meth_sendto(lua_State *L) {
     err = getaddrinfo(ip, port, &aihint, &ai);
 	if (err) {
         lua_pushnil(L);
-        lua_pushstring(L, gai_strerror(err));
+        lua_pushstring(L, gai_strerrorA(err));
         return 2;
     }
 
@@ -290,7 +290,7 @@ static int meth_receivefrom(lua_State *L) {
         INET6_ADDRSTRLEN, portstr, 6, NI_NUMERICHOST | NI_NUMERICSERV);
 	if (err) {
         lua_pushnil(L);
-        lua_pushstring(L, gai_strerror(err));
+        lua_pushstring(L, gai_strerrorA(err));
         if (wanted > sizeof(buf)) free(dgram);
         return 2;
     }

--- a/src/wsocket.c
+++ b/src/wsocket.c
@@ -429,6 +429,6 @@ const char *socket_gaistrerror(int err) {
 #ifdef EAI_SYSTEM
         case EAI_SYSTEM: return strerror(errno);
 #endif
-        default: return gai_strerror(err);
+        default: return gai_strerrorA(err);
     }
 }


### PR DESCRIPTION
Although this only generated a warning in my VS2019 setup, call `gai_strerror` seems like will not work in 64bit, so I am submitting this PR. Calling `gai_strerrorA` directly calls the `char` version of the function even when building for 64bit.