### PR TITLE
feature: MSYS2 support on src/makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,81 @@ jobs:
           lua urltest.lua
           lua test_socket_error.lua
           kill %1
+
+  build-msys2:
+    name: Test ${{ matrix.Lua.version }} via MSYS2 package mingw-w64-${{ matrix.MSYS2.env }}-${{ matrix.Lua.msys2_pkg_name }}
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        Lua:
+          # For future updates:
+          #   the fields 'msys2_pkg_name' and 'msys2_lua_exe'
+          #   in the matrix below are always 'lua'
+          #   for the current Lua version .
+          - { version: '5.4', msys2_pkg_name: 'lua', msys2_lua_exe: 'lua' }
+          - { version: '5.3', msys2_pkg_name: 'lua53', msys2_lua_exe: 'lua5.3' }
+          # At the moment, Lua 5.2 is not on MSYS2 repositories.
+          - { version: '5.1', msys2_pkg_name: 'lua51', msys2_lua_exe: 'lua5.1' }
+          - { version: '5.1', msys2_pkg_name: 'luajit', msys2_lua_exe: 'luajit' }
+        MSYS2:
+          - { sys: ucrt64,  env: ucrt-x86_64 }
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+          - { sys: clang64, env: clang-x86_64 }
+          - { sys: clang32, env: clang-i686 }
+    defaults:
+      run:
+        shell: msys2 {0}
+    env:
+      LUA_EXE: /${{ matrix.MSYS2.sys }}/bin/${{ matrix.Lua.msys2_lua_exe }}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        name: Setup MSYS2
+        with:
+          msystem: ${{ matrix.MSYS2.sys }}
+          install: |
+            base-devel
+            git
+            mingw-w64-${{ matrix.MSYS2.env }}-cc
+            mingw-w64-${{ matrix.MSYS2.env }}-${{ matrix.Lua.msys2_pkg_name }}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        if: ${{ !contains(matrix.Lua.msys2_pkg_name, 'luajit') }}
+        run: |
+          make -C src \
+            PLAT=msys2${{ matrix.MSYS2.sys }} \
+            LUAV=${{ matrix.Lua.version }} \
+            DEBUG=DEBUG \
+            all
+      - name: Build with luajit
+        if: ${{ contains(matrix.Lua.msys2_pkg_name, 'luajit') }}
+        run: |
+          make -C src \
+            PLAT=msys2${{ matrix.MSYS2.sys }} \
+            LUAV=${{ matrix.Lua.version }} \
+            DEBUG=DEBUG \
+            "MYCFLAGS=$(pkgconf.exe --cflags lua${{ matrix.Lua.version }})" \
+            all
+      - name: Install
+        run: |
+          make -C src \
+            PLAT=msys2${{ matrix.MSYS2.sys }} \
+            LUAV=${{ matrix.Lua.version }} \
+            DEBUG=DEBUG \
+            install
+      - name: Run regression tests
+        run: |
+          cd test
+          ${{ env.LUA_EXE }} hello.lua
+          ${{ env.LUA_EXE }} testsrvr.lua > /dev/null &
+          ${{ env.LUA_EXE }} testclnt.lua
+          ${{ env.LUA_EXE }} stufftest.lua
+          ${{ env.LUA_EXE }} excepttest.lua
+          ${{ env.LUA_EXE }} test_bind.lua
+          ${{ env.LUA_EXE }} test_getaddrinfo.lua
+          ${{ env.LUA_EXE }} ltn12test.lua
+          ${{ env.LUA_EXE }} mimetest.lua
+          ${{ env.LUA_EXE }} urltest.lua
+          ${{ env.LUA_EXE }} test_socket_error.lua
+          kill %1

--- a/src/makefile
+++ b/src/makefile
@@ -12,7 +12,7 @@
 #
 #   make PLAT=linux DEBUG=DEBUG LUAV=5.2 prefix=/sw
 
-# PLAT: linux macosx win32 win64 mingw
+# PLAT: linux macosx win32 win64 mingw msys2ucrt64 msys2mingw64 msys2mingw32 msys2clang64 msys2clang32 msys2clangarm64
 # platform to build for
 PLAT?=linux
 
@@ -74,6 +74,77 @@ LUAPREFIX_mingw?=/usr
 CDIR_mingw?=lua/$(LUAV)
 LDIR_mingw?=lua/$(LUAV)/lua
 
+# where lua headers are found for msys2ucrt64 builds
+# LUAINC_msys2ucrt64:
+# /ucrt64/include
+# /ucrt64/include/lua$(LUAV)
+LUAINC_msys2ucrt64_base?=/ucrt64/include
+LUAINC_msys2ucrt64?=$(LUAINC_msys2ucrt64_base)/lua$(LUAV)
+LUALIB_msys2ucrt64_base?=/ucrt64/bin
+LUALIB_msys2ucrt64?=$(LUALIB_msys2ucrt64_base)/lua$(subst .,,$(LUAV)).dll
+LUAPREFIX_msys2ucrt64?=/ucrt64
+CDIR_msys2ucrt64?=lib/lua/$(LUAV)
+LDIR_msys2ucrt64?=share/lua/$(LUAV)
+
+# where lua headers are found for msys2mingw64 builds
+# LUAINC_msys2mingw64:
+# /mingw64/include
+# /mingw64/include/lua$(LUAV)
+LUAINC_msys2mingw64_base?=/mingw64/include
+LUAINC_msys2mingw64?=$(LUAINC_msys2mingw64_base)/lua$(LUAV)
+LUALIB_msys2mingw64_base?=/mingw64/bin
+LUALIB_msys2mingw64?=$(LUALIB_msys2mingw64_base)/lua$(subst .,,$(LUAV)).dll
+LUAPREFIX_msys2mingw64?=/mingw64
+CDIR_msys2mingw64?=lib/lua/$(LUAV)
+LDIR_msys2mingw64?=share/lua/$(LUAV)
+
+# where lua headers are found for msys2mingw32 builds
+# LUAINC_msys2mingw32:
+# /mingw32/include
+# /mingw32/include/lua$(LUAV)
+LUAINC_msys2mingw32_base?=/mingw32/include
+LUAINC_msys2mingw32?=$(LUAINC_msys2mingw32_base)/lua$(LUAV)
+LUALIB_msys2mingw32_base?=/mingw32/bin
+LUALIB_msys2mingw32?=$(LUALIB_msys2mingw32_base)/lua$(subst .,,$(LUAV)).dll
+LUAPREFIX_msys2mingw32?=/mingw32
+CDIR_msys2mingw32?=lib/lua/$(LUAV)
+LDIR_msys2mingw32?=share/lua/$(LUAV)
+
+# where lua headers are found for msys2clang64 builds
+# LUAINC_msys2clang64:
+# /clang64/include
+# /clang64/include/lua$(LUAV)
+LUAINC_msys2clang64_base?=/clang64/include
+LUAINC_msys2clang64?=$(LUAINC_msys2clang64_base)/lua$(LUAV)
+LUALIB_msys2clang64_base?=/clang64/bin
+LUALIB_msys2clang64?=$(LUALIB_msys2clang64_base)/lua$(subst .,,$(LUAV)).dll
+LUAPREFIX_msys2clang64?=/clang64
+CDIR_msys2clang64?=lib/lua/$(LUAV)
+LDIR_msys2clang64?=share/lua/$(LUAV)
+
+# where lua headers are found for msys2clang32 builds
+# LUAINC_msys2clang32:
+# /clang32/include
+# /clang32/include/lua$(LUAV)
+LUAINC_msys2clang32_base?=/clang32/include
+LUAINC_msys2clang32?=$(LUAINC_msys2clang32_base)/lua$(LUAV)
+LUALIB_msys2clang32_base?=/clang32/bin
+LUALIB_msys2clang32?=$(LUALIB_msys2clang32_base)/lua$(subst .,,$(LUAV)).dll
+LUAPREFIX_msys2clang32?=/clang32
+CDIR_msys2clang32?=lib/lua/$(LUAV)
+LDIR_msys2clang32?=share/lua/$(LUAV)
+
+# where lua headers are found for msys2clangarm64 builds
+# LUAINC_msys2clangarm64:
+# /clangarm64/include
+# /clangarm64/include/lua$(LUAV)
+LUAINC_msys2clangarm64_base?=/clangarm64/include
+LUAINC_msys2clangarm64?=$(LUAINC_msys2clangarm64_base)/lua$(LUAV)
+LUALIB_msys2clangarm64_base?=/clangarm64/bin
+LUALIB_msys2clangarm64?=$(LUALIB_msys2clangarm64_base)/lua$(subst .,,$(LUAV)).dll
+LUAPREFIX_msys2clangarm64?=/clangarm64
+CDIR_msys2clangarm64?=lib/lua/$(LUAV)
+LDIR_msys2clangarm64?=share/lua/$(LUAV)
 
 # LUAINC_win32:
 # LUALIB_win32:
@@ -153,7 +224,7 @@ print:
 #------
 # Supported platforms
 #
-PLATS= macosx linux win32 win64 mingw solaris
+PLATS= macosx linux win32 win64 mingw msys2ucrt64 msys2mingw64 msys2mingw32 msys2clang64 msys2clang32 msys2clangarm64 solaris
 
 #------
 # Compiler and linker settings
@@ -219,6 +290,77 @@ LDFLAGS_mingw= $(LUALIB) -shared -Wl,-s -lws2_32 -o
 LD_mingw=gcc
 SOCKET_mingw=wsocket.o
 
+#------
+# Compiler and linker settings
+# for MSYS2 ucrt64
+SO_msys2ucrt64=dll
+O_msys2ucrt64=o
+CC_msys2ucrt64=/ucrt64/bin/cc
+DEF_msys2ucrt64= -DLUASOCKET_$(DEBUG)
+CFLAGS_msys2ucrt64=$(LUAINC:%=-I%) $(DEF) -Wall -O2 -fno-common
+LDFLAGS_msys2ucrt64= $(LUALIB) -shared -Wl,-s -lws2_32 -o
+LD_msys2ucrt64=/ucrt64/bin/cc
+SOCKET_msys2ucrt64=wsocket.o
+
+#------
+# Compiler and linker settings
+# for MSYS2 mingw64
+SO_msys2mingw64=dll
+O_msys2mingw64=o
+CC_msys2mingw64=/mingw64/bin/cc
+DEF_msys2mingw64= -DLUASOCKET_$(DEBUG)
+CFLAGS_msys2mingw64=$(LUAINC:%=-I%) $(DEF) -Wall -O2 -fno-common
+LDFLAGS_msys2mingw64= $(LUALIB) -shared -Wl,-s -lws2_32 -o
+LD_msys2mingw64=/mingw64/bin/cc
+SOCKET_msys2mingw64=wsocket.o
+
+#------
+# Compiler and linker settings
+# for MSYS2 mingw32
+SO_msys2mingw32=dll
+O_msys2mingw32=o
+CC_msys2mingw32=/mingw32/bin/cc
+DEF_msys2mingw32= -DLUASOCKET_$(DEBUG)
+CFLAGS_msys2mingw32=$(LUAINC:%=-I%) $(DEF) -Wall -O2 -fno-common
+LDFLAGS_msys2mingw32= $(LUALIB) -shared -Wl,-s -lws2_32 -o
+LD_msys2mingw32=/mingw32/bin/cc
+SOCKET_msys2mingw32=wsocket.o
+
+#------
+# Compiler and linker settings
+# for MSYS2 clang64
+SO_msys2clang64=dll
+O_msys2clang64=o
+CC_msys2clang64=/clang64/bin/cc
+DEF_msys2clang64= -DLUASOCKET_$(DEBUG)
+CFLAGS_msys2clang64=$(LUAINC:%=-I%) $(DEF) -Wall -O2 -fno-common
+LDFLAGS_msys2clang64= $(LUALIB) -shared -Wl,-s -lws2_32 -o
+LD_msys2clang64=/clang64/bin/cc
+SOCKET_msys2clang64=wsocket.o
+
+#------
+# Compiler and linker settings
+# for MSYS2 clang32
+SO_msys2clang32=dll
+O_msys2clang32=o
+CC_msys2clang32=/clang32/bin/cc
+DEF_msys2clang32= -DLUASOCKET_$(DEBUG)
+CFLAGS_msys2clang32=$(LUAINC:%=-I%) $(DEF) -Wall -O2 -fno-common
+LDFLAGS_msys2clang32= $(LUALIB) -shared -Wl,-s -lws2_32 -o
+LD_msys2clang32=/clang32/bin/cc
+SOCKET_msys2clang32=wsocket.o
+
+#------
+# Compiler and linker settings
+# for MSYS2 clangarm64
+SO_msys2clangarm64=dll
+O_msys2clangarm64=o
+CC_msys2clangarm64=/clangarm64/bin/cc
+DEF_msys2clangarm64= -DLUASOCKET_$(DEBUG)
+CFLAGS_msys2clangarm64=$(LUAINC:%=-I%) $(DEF) -Wall -O2 -fno-common
+LDFLAGS_msys2clangarm64= $(LUALIB) -shared -Wl,-s -lws2_32 -o
+LD_msys2clangarm64=/clangarm64/bin/cc
+SOCKET_msys2clangarm64=wsocket.o
 
 #------
 # Compiler and linker settings
@@ -383,6 +525,24 @@ linux:
 
 mingw:
 	$(MAKE) all PLAT=mingw
+
+msys2ucrt64:
+	$(MAKE) all PLAT=msys2ucrt64
+
+msys2mingw64:
+	$(MAKE) all PLAT=msys2mingw64
+
+msys2mingw32:
+	$(MAKE) all PLAT=msys2mingw32
+
+msys2clang64:
+	$(MAKE) all PLAT=msys2clang64
+
+msys2clang32:
+	$(MAKE) all PLAT=msys2clang32
+
+msys2clangarm64:
+	$(MAKE) all PLAT=msys2clangarm64
 
 solaris:
 	$(MAKE) all-unix PLAT=solaris


### PR DESCRIPTION
## Description

The changes in the ```src/makefile``` allows to build luasocket on [MSYS2](https://www.msys2.org/) shells with the compiler toolchain for each environment:
*  ```mingw32```
*  ```mingw64```
*  ```ucrt64```
*  ```clang32```
*  ```clang64```
*  ```clangarm64```

## How to test the changes

### Initial setup of tools (only once)
1. Go to [https://www.msys2.org/](https://www.msys2.org/), download the installer and install MSYS2;
2. Type ```ucrt64``` on Windows start menu to open a MSYS2 shell for the ucrt64 environment listed above;
3. Update core system packages
    ```bash
    pacman -Syuu
    ```
4. Sync package database
    ```bash
    pacman -Syuu
    ```
5. Install useful linux tools, git, a C compiler and Lua 5.1:
    ```bash
    pacman -S --needed base-devel git mingw-w64-ucrt-x86_64-cc mingw-w64-ucrt-x86_64-lua51
    ```
6. Change to ```/tmp``` directory and clone my branch
    ```bash
    cd /tmp && git clone --branch=msys2-makefile https://github.com/luau-project/luasocket
    ```
7. Leave the shell opened for the test

### Test
1. In the same shell above, build luasocket for ucrt64 environment:
    ```bash
    make -C luasocket/src PLAT=msys2ucrt64 LUAV=5.1 all
    ```
2. Install the library:
    ```bash
    make -C luasocket/src PLAT=msys2ucrt64 LUAV=5.1 install
    ```
3. Run a simple test
    ```bash
    lua5.1 luasocket/test/hello.lua
    ```
4. Enjoy.

> [!NOTE]
> 
> Lua C modules get installed at ```/ucrt64/lib/lua/5.1``` and .lua files at ```/ucrt64/share/lua/5.1``` for the ucrt64 environment, in case you want to remove them.

## Extra

If you guys want, I can contribute a Github workflow to test luasocket on MSYS2 tools. 